### PR TITLE
Check if Bluetooth Service Service Starts on Reboot 

### DIFF
--- a/app/src/main/java/org/covidwatch/android/CovidWatchApplication.kt
+++ b/app/src/main/java/org/covidwatch/android/CovidWatchApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
@@ -67,6 +68,14 @@ class CovidWatchApplication : Application() {
         }
     }
 
+    fun bluetoothServiceStatusChanged(serviceStarted: Boolean){
+        val firstUse = preferences.getBoolean(MainFragment.INITIAL_VISIT, true)
+        if (!serviceStarted && !firstUse){
+            Toast.makeText(this,"Please turn on Bluetooth", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private lateinit var preferences: SharedPreferences
     override fun onCreate() {
         super.onCreate()
 
@@ -84,15 +93,14 @@ class CovidWatchApplication : Application() {
             CurrentUserExposureNotifier(this)
         currentUserExposureNotifier.startObservingLocalContactEvents()
 
-        val isContactEventLoggingEnabled = getSharedPreferences(
+        preferences = getSharedPreferences(
             getString(R.string.preference_file_key), Context.MODE_PRIVATE
-        ).getBoolean(
+        )
+        val isContactEventLoggingEnabled = preferences.getBoolean(
             getString(R.string.preference_is_contact_event_logging_enabled),
             false
         )
         configureAdvertising(isContactEventLoggingEnabled)
-
-
     }
 
     private fun schedulePeriodicPublicContactEventsRefresh() {

--- a/app/src/main/java/org/covidwatch/android/ui/MainFragment.kt
+++ b/app/src/main/java/org/covidwatch/android/ui/MainFragment.kt
@@ -20,7 +20,6 @@ import org.covidwatch.android.databinding.FragmentMainBinding
  */
 class MainFragment : Fragment() {
     private lateinit var preferences : SharedPreferences
-    private val INITIAL_VISIT = "INITIAL_VISIT"
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -63,6 +62,7 @@ class MainFragment : Fragment() {
     }
 
     companion object {
+        const val INITIAL_VISIT = "INITIAL_VISIT"
         @JvmStatic
         fun newInstance(param1: String, param2: String) = MainFragment()
     }


### PR DESCRIPTION
https://github.com/covid19risk/covidwatch-android/issues/30
The details on this ticket were a little light, so if I misinterpreted the intent please let me know. 
 I added callback function into the Covid Application class that the Bluetooth service could trigger if something went wrong with initialization.  Examples of things that could go wrong include:
* Bluetooth is turned off
* The service fails to bind
* The binding dies
* The service disconnects
