### PR TITLE
notify-user-bluetooth

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.covidwatch.android">
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
     <application
         android:name=".CovidWatchApplication"
         android:allowBackup="true"
@@ -12,14 +14,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <service android:name=".ble.EnableBluetoothService"/>
 
         <activity
             android:name=".ui.MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
+
 </manifest>

--- a/app/src/main/java/org/covidwatch/android/CovidWatchApplication.kt
+++ b/app/src/main/java/org/covidwatch/android/CovidWatchApplication.kt
@@ -2,6 +2,7 @@ package org.covidwatch.android
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.lifecycle.Lifecycle
@@ -13,6 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.covidwatch.android.ble.BluetoothManagerImpl
+import org.covidwatch.android.ble.EnableBluetoothService
 import org.covidwatch.android.data.CovidWatchDatabase
 import org.covidwatch.android.data.firestore.ContactEventsDownloadWorker
 import org.covidwatch.android.data.firestore.LocalContactEventsUploader
@@ -69,7 +71,7 @@ class CovidWatchApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-
+        startEnableBluetoothService()
         getSharedPreferences(
             getString(R.string.preference_file_key),
             Context.MODE_PRIVATE
@@ -93,6 +95,11 @@ class CovidWatchApplication : Application() {
         configureAdvertising(isContactEventLoggingEnabled)
 
 
+    }
+
+    private fun startEnableBluetoothService(){
+        val intent = Intent(this, EnableBluetoothService::class.java)
+        this.startService(intent)
     }
 
     private fun schedulePeriodicPublicContactEventsRefresh() {

--- a/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
+++ b/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
@@ -58,7 +58,6 @@ class BluetoothManagerImpl(
                 )
                 start()
             }
-
             runTimer()
         }
 

--- a/app/src/main/java/org/covidwatch/android/ble/EnableBluetoothService.kt
+++ b/app/src/main/java/org/covidwatch/android/ble/EnableBluetoothService.kt
@@ -1,12 +1,83 @@
 package org.covidwatch.android.ble
 
-import android.app.Service
+import android.app.*
+import android.bluetooth.BluetoothAdapter
+import android.content.Context
 import android.content.Intent
-import android.os.IBinder
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import org.covidwatch.android.MainFragment.Companion.INITIAL_VISIT
+import org.covidwatch.android.R
+import org.covidwatch.android.ui.MainActivity
+import java.util.*
+import java.util.concurrent.TimeUnit
 
-class EnableBluetoothService : Service() {
+class EnableBluetoothService : IntentService("EnableBluetoothService") {
 
-    override fun onBind(intent: Intent): IBinder {
-        TODO("Return the communication channel to the service.")
+    private val CHANNEL_ID = "EnableBluetoothServiceChannel"
+    private val NOTIF_ID = 15
+    private val POLLING_INTERVAL = 5L
+    private var timer: Timer? = null
+
+    override fun onHandleIntent(intent: Intent?) {
+        startPolling()
+    }
+
+    private fun startPolling(){
+        timer?.cancel()
+        timer = Timer()
+        timer?.scheduleAtFixedRate(
+            object : TimerTask() {
+                override fun run() {
+                    checkIfBluetoothIsOn()
+                }
+            },
+            TimeUnit.MINUTES.toMillis(POLLING_INTERVAL),
+            TimeUnit.MINUTES.toMillis(POLLING_INTERVAL)
+        )
+    }
+
+    private fun checkIfBluetoothIsOn(){
+        val initialVisit = getSharedPreferences(
+            getString(R.string.preference_file_key), Context.MODE_PRIVATE
+        ).getBoolean(INITIAL_VISIT,false)
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        if ((adapter == null || !adapter.isEnabled) && !initialVisit){
+            NotificationManagerCompat.from(this).notify(NOTIF_ID,foregroundNotification())
+        } else {
+            NotificationManagerCompat.from(this).cancel(NOTIF_ID)
+        }
+    }
+
+    private fun foregroundNotification(): Notification {
+        createNotificationChannelIfNeeded()
+
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(this.getString(R.string.enable_bluetooth_notification))
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentIntent(pendingIntent)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .build()
+    }
+
+    private fun createNotificationChannelIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val serviceChannel = NotificationChannel(
+                CHANNEL_ID,
+                "Foreground Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = ContextCompat.getSystemService(
+                this, NotificationManager::class.java
+            )
+            manager?.createNotificationChannel(serviceChannel)
+        }
     }
 }

--- a/app/src/main/java/org/covidwatch/android/ble/EnableBluetoothService.kt
+++ b/app/src/main/java/org/covidwatch/android/ble/EnableBluetoothService.kt
@@ -1,0 +1,12 @@
+package org.covidwatch.android.ble
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class EnableBluetoothService : Service() {
+
+    override fun onBind(intent: Intent): IBinder {
+        TODO("Return the communication channel to the service.")
+    }
+}

--- a/app/src/main/java/org/covidwatch/android/ui/MainFragment.kt
+++ b/app/src/main/java/org/covidwatch/android/ui/MainFragment.kt
@@ -20,7 +20,7 @@ import org.covidwatch.android.databinding.FragmentMainBinding
  */
 class MainFragment : Fragment() {
     private lateinit var preferences : SharedPreferences
-    private val INITIAL_VISIT = "INITIAL_VISIT"
+
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -63,6 +63,7 @@ class MainFragment : Fragment() {
     }
 
     companion object {
+        const val INITIAL_VISIT = "INITIAL_VISIT"
         @JvmStatic
         fun newInstance(param1: String, param2: String) = MainFragment()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,5 +71,6 @@
     <string name="main_subtext_2">Share your result anonymously to help your community stay safe.</string>
     <string name="contact_alert_text">You may have been in contact with COVID-19</string>
     <string name="share_intent_text">Help your community stay safe, anonymously:</string>
+    <string name="enable_bluetooth_notification">Please turn on bluetooth to enable Covid Watch to function.</string>
 
 </resources>


### PR DESCRIPTION
https://github.com/covid19risk/covidwatch-android/issues/26
Added timer task in IntentService that launches a foreground notification if a user turns off their bluetooth. Not sure how to observe the user turning on bluetooth in a battery efficient manner.  Open to suggestions.