### PR TITLE
Use guava android to avoid firestore guava conflict

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.2.4'
     implementation "androidx.work:work-runtime-ktx:2.3.4"
     implementation "com.google.firebase:firebase-firestore-ktx:21.4.2"
-    implementation 'com.google.guava:guava:28.2-jre'
+    implementation 'com.google.guava:guava:29.0-android'
     implementation 'com.github.TCNCoalition:tcn-client-android:0.0.1'
 
     implementation 'pub.devrel:easypermissions:3.0.0'


### PR DESCRIPTION
Fixes https://github.com/covid19risk/covidwatch-android/issues/79

Source: https://stackoverflow.com/a/58294757/5222156