### PR TITLE
Added if/else clause for Android O devices and above.

### DIFF
--- a/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
+++ b/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
@@ -24,6 +24,7 @@ import org.tcncoalition.tcnclient.toUUID
 import java.util.*
 import java.util.concurrent.TimeUnit
 
+
 interface BluetoothManager {
     fun startAdvertiser(cen: Cen)
     fun stopAdvertiser()
@@ -109,7 +110,8 @@ class BluetoothManagerImpl(
     override fun startService(cen: Cen) {
         cenGenerator.cen = cen
         app.bindService(intent, serviceConnection, BIND_AUTO_CREATE)
-        app.startService(intent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) app.startForegroundService(intent)
+        else app.startService(intent)
     }
 
     override fun stopAdvertiser() {


### PR DESCRIPTION
https://github.com/covid19risk/covidwatch-android/issues/80#event-3244660757
I think this crash lies at least partially in our court. If the library doesn't support launching a foreground service however then they'll need to make changes as well. The fix was based on https://stackoverflow.com/a/47654126/4520965 . This PR should address our side of the issue.  I tested the solution by running 
```
adb -s FA71N0300294 logcat > logcat.txt
```
While launching the app, restarting the device, and then re-launching the app.  I was unable to reproduce the crash after the fix.