### PR TITLE
Fixed crash caused by bluetoothLeAdvertiser NPE.

### DIFF
--- a/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
+++ b/app/src/main/java/org/covidwatch/android/ble/BluetoothManager.kt
@@ -1,6 +1,7 @@
 package org.covidwatch.android.ble
 
 import android.app.*
+import android.bluetooth.BluetoothAdapter
 import android.content.ComponentName
 import android.content.Context
 import android.content.Context.BIND_AUTO_CREATE
@@ -57,7 +58,7 @@ class BluetoothManagerImpl(
                         foregroundNotification()
                     )
                 )
-                start()
+                if (BluetoothAdapter.getDefaultAdapter().bluetoothLeAdvertiser != null) start()
             }
 
             runTimer()


### PR DESCRIPTION
https://github.com/covid19risk/covidwatch-android/issues/84
Fairly straightforward fix: ensure bluetoothLeAdvertiser isn't null before starting the service.  This occurs because the user has manually turned off bluetooth.  Thanks to https://github.com/covid19risk/covidwatch-android/issues/74 this edge case is now addressed by the UI.