### PR TITLE
Adding a workflow for CI on feature branches

### DIFF
--- a/.github/workflows/android-feature-push.yml
+++ b/.github/workflows/android-feature-push.yml
@@ -25,9 +25,10 @@ jobs:
         java-version: 1.8
     - name: Clean, Build, Test
       run: bash ./gradlew clean build --stacktrace
+    - name: Grab pushed branch name
+      uses: nelonoel/branch-name@v1
     - name: Update SonarQube
       env:
         LOGIN_KEY: ${{ secrets.SONARCLOUD_LOGIN_KEY }}
-        PUSH_BRANCH: github.event.push.head.ref
-      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=$PUSH_BRANCH -Dsonar.branch.target=develop --stacktrace
+      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=@BRANCH_NAME -Dsonar.branch.target=develop --stacktrace
 

--- a/.github/workflows/android-feature-push.yml
+++ b/.github/workflows/android-feature-push.yml
@@ -1,0 +1,33 @@
+name: Feature Branch Push CI
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+      - '!develop'
+
+jobs:
+
+  test:
+    name: CI Testing
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Fetch all branches
+      run: |
+        git fetch --prune --unshallow
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Clean, Build, Test
+      run: bash ./gradlew clean build --stacktrace
+    - name: Update SonarQube
+      env:
+        LOGIN_KEY: ${{ secrets.SONARCLOUD_LOGIN_KEY }}
+        PUSH_BRANCH: github.event.push.head.ref
+      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=$PUSH_BRANCH -Dsonar.branch.target=develop --stacktrace
+

--- a/.github/workflows/android-feature-push.yml
+++ b/.github/workflows/android-feature-push.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Update SonarQube
       env:
         LOGIN_KEY: ${{ secrets.SONARCLOUD_LOGIN_KEY }}
-      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=@BRANCH_NAME -Dsonar.branch.target=develop --stacktrace
+      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=$BRANCH_NAME -Dsonar.branch.target=develop --stacktrace
 

--- a/.github/workflows/android-feature-push.yml
+++ b/.github/workflows/android-feature-push.yml
@@ -16,19 +16,11 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-    - name: Fetch all branches
-      run: |
-        git fetch --prune --unshallow
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Clean, Build, Test
       run: bash ./gradlew clean build --stacktrace
-    - name: Grab pushed branch name
-      uses: nelonoel/branch-name@v1
-    - name: Update SonarQube
-      env:
-        LOGIN_KEY: ${{ secrets.SONARCLOUD_LOGIN_KEY }}
-      run: bash ./gradlew sonarqube -Dsonar.login=$LOGIN_KEY -Dsonar.branch.name=$BRANCH_NAME -Dsonar.branch.target=develop --stacktrace
+
 


### PR DESCRIPTION
This new Github action workflow would run CI/Sonar on all feature branches, but not generate APKs. Could easily add in APK generation if it's desired, just seems like overkill for now.