### PR TITLE
Sync project-level dictionaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ captures/
 .idea/tasks.xml
 .idea/gradle.xml
 .idea/assetWizardSettings.xml
-.idea/dictionaries
 .idea/libraries
 .idea/vcs.xml
 # Android Studio 3 in .gitignore file.

--- a/.idea/dictionaries/harry.xml
+++ b/.idea/dictionaries/harry.xml
@@ -1,0 +1,8 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="harry">
+    <words>
+      <w>covid</w>
+      <w>koin</w>
+    </words>
+  </dictionary>
+</component>


### PR DESCRIPTION
Building on my cleanup of our `.gitignore`, I propose adding project-level dictionaries to VCS so that custom words (an IDE feature I use often as spellcheck warnings bother me) can be added to project config.