### PR TITLE
Add crashlytics -- issue #132

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: "com.vanniktech.android.junit.jacoco"
 apply plugin: "org.sonarqube"
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion 29
@@ -91,6 +92,10 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     implementation "androidx.fragment:fragment-ktx:1.2.4"
     implementation "androidx.work:work-runtime-ktx:2.3.4"
+    //Google Analytics dependency.
+    implementation 'com.google.firebase:firebase-analytics:17.4.0'
+    //Firebase Crashlytics dependency.
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
 
     def nav_version = "2.2.1"
     implementation "androidx.navigation:navigation-fragment:$nav_version"

--- a/app/src/main/java/org/covidwatch/android/CovidWatchTcnManager.kt
+++ b/app/src/main/java/org/covidwatch/android/CovidWatchTcnManager.kt
@@ -20,6 +20,7 @@ import org.covidwatch.android.data.signedreport.SignedReportDAO
 import org.covidwatch.android.presentation.MainActivity
 import org.tcncoalition.tcnclient.TcnKeys
 import org.tcncoalition.tcnclient.TcnManager
+import org.tcncoalition.tcnclient.crypto.MemoType
 import java.util.*
 
 class CovidWatchTcnManager(
@@ -104,7 +105,7 @@ class CovidWatchTcnManager(
     fun generateAndUploadReport() {
         // Create a new Signed Report with `uploadState` set to `.notUploaded` and store it in the local persistent store.
         // This will kick off an observer that watches for signed reports which were not uploaded and will upload it.
-        val signedReport = SignedReport(tcnKeys.createReport())
+        val signedReport = SignedReport(tcnKeys.createReport("Hello, World!".toByteArray(),MemoType.CovidWatchV1))
         signedReport.isProcessed = true
         signedReport.uploadState = SignedReport.UploadState.NOTUPLOADED
         GlobalScope.launch(Dispatchers.IO) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
@@ -12,6 +15,8 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.3'
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8"
+        // Add the Fabric Crashlytics plugin.
+        classpath 'io.fabric.tools:gradle:1.31.2'
     }
 }
 


### PR DESCRIPTION
Added Firebase Crashlytics support.  Tested with Crashlytics crash function and with dividing by 0. You can see the result of the tests in the Firebase Console.